### PR TITLE
Add support Android NDK standalone toolchain

### DIFF
--- a/CMakeLists.original.txt
+++ b/CMakeLists.original.txt
@@ -183,7 +183,7 @@ DumpMachine(CRYPTOPP_X32 "x32")
 DumpMachine(CRYPTOPP_AARCH32 "Aarch32")
 DumpMachine(CRYPTOPP_AARCH64 "Aarch64")
 DumpMachine(CRYPTOPP_ARMHF "armhf|arm7l|eabihf")
-DumpMachine(CRYPTOPP_ARM "\\<arm\\>")
+DumpMachine(CRYPTOPP_ARM "\\<arm\\>|armv")
 
 ###############################################################################
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -43,6 +43,8 @@ class CryptoPPConan(ConanFile):
         cmake.definitions["BUILD_SHARED"] = self.options.shared
         cmake.definitions["BUILD_TESTING"] = False
         cmake.definitions["BUILD_DOCUMENTATION"] = False
+        if self.settings.os == 'Android':
+            cmake.definitions["CRYPTOPP_NATIVE_ARCH"] = True
         cmake.configure()
         return cmake
 


### PR DESCRIPTION
For Android NDK Standalone toolchain `-dumpmachine` returns:

```
arm-linux-androideabi-clang++ -dumpmachine
armv7a-none-linux-android16
```

> This toolchain created with `$ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py --arch arm --api 16 --install-dir /opt/arm-16-toolchain`