### PR TITLE
Cryptopp expect cpu-feature.h to be copied to source directory

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -30,6 +30,8 @@ class CryptoPPConan(ConanFile):
         os.rename("cryptopp-%s" % archive_file, self._source_subfolder)
         shutil.move("CMakeLists.original.txt", os.path.join(self._source_subfolder, "CMakeLists.txt"))
         tools.patch(patch_file="a0f91aeb2587.patch", base_path=self._source_subfolder)
+        if self.settings.os == 'Android' and 'ANDROID_NDK_HOME' in os.environ:
+            shutil.copyfile(os.environ['ANDROID_NDK_HOME'] + '/sources/android/cpufeatures/cpu-features.h', os.path.join(self._source_subfolder, "cpu-features.h"))
 
     def config_options(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
According to https://github.com/weidai11/cryptopp/blob/CRYPTOPP_7_0_0/cpu.cpp#L46-L50 `cpu-feature.h` expected to be in cryptopp source dir

It should be copied by `setenv-android.sh` 

But because there is not much reason to call `setenv-android.sh` I propose to copy it with `conanfile.py` if ANDROID_NDK_HOME env present